### PR TITLE
Stage 0+1: shared tokenizer/data prep, TransformerTrunk refactor, base pretraining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,12 @@ __marimo__/
 
 # Ignore .zip files
 *.zip
+
+# Pipeline data artifacts — reproducible via prepare_pipeline_data.py
+data/raw/
+data/raw_text/
+data/tokenized/
+data/sft_dataset.json
+data/reasoning_dataset.json
+data/preference_dataset.json
+checkpoints/

--- a/inference.py
+++ b/inference.py
@@ -16,7 +16,9 @@ from model.generate import generate
 from tokenizer import BPETokenizer
 
 
-def load_checkpoint(checkpoint_path: str, device: torch.device) -> tuple[TinyLLM, BPETokenizer]:
+def load_checkpoint(
+    checkpoint_path: str, device: torch.device, tokenizer_path: str | None = None
+) -> tuple[TinyLLM, BPETokenizer]:
     """Load model and tokenizer from a training checkpoint."""
     print(f"Loading checkpoint: {checkpoint_path}")
     checkpoint = torch.load(checkpoint_path, map_location=device)
@@ -27,8 +29,11 @@ def load_checkpoint(checkpoint_path: str, device: torch.device) -> tuple[TinyLLM
     model.load_state_dict(checkpoint["model_state_dict"])
     model.eval()
 
-    tok_path = checkpoint.get("train_config", {}).get("data_dir", "data") + "/tokenizer.json"
-    tokenizer = BPETokenizer.load(tok_path)
+    if tokenizer_path is None:
+        # train.py checkpoints carry "train_config"; pretrain.py's don't, so this falls
+        # back to the (usually wrong) default — pass --tokenizer_path explicitly for those.
+        tokenizer_path = checkpoint.get("train_config", {}).get("data_dir", "data") + "/tokenizer.json"
+    tokenizer = BPETokenizer.load(tokenizer_path)
 
     print(f"Params     : {sum(p.numel() for p in model.parameters()) / 1e6:.2f}M")
     print(f"Vocab size : {tokenizer.vocab_size}")
@@ -71,6 +76,8 @@ def run_inference(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate text with TinyLLM")
     parser.add_argument("--checkpoint",   type=str,   default="checkpoints/latest.pt")
+    parser.add_argument("--tokenizer_path", type=str, default=None,
+                         help="Override tokenizer path (required for pretrain.py checkpoints)")
     parser.add_argument("--prompt",       type=str,   default="To be or not to be")
     parser.add_argument("--max_tokens",   type=int,   default=200)
     parser.add_argument("--temperature",  type=float, default=0.8)
@@ -83,7 +90,7 @@ def main() -> None:
              if args.device == "auto" else torch.device(args.device)
     print(f"Device: {device}")
 
-    model, tokenizer = load_checkpoint(args.checkpoint, device)
+    model, tokenizer = load_checkpoint(args.checkpoint, device, tokenizer_path=args.tokenizer_path)
 
     result = run_inference(
         model, tokenizer,

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -4,11 +4,13 @@ from model.config import KVCache, ModelConfig, build_kv_cache
 from model.generate import generate
 from model.model import TinyLLM
 from model.sampling import sample
+from model.trunk import TransformerTrunk
 from model.types import CacheList, LogitsAndLoss, OptionalCacheList
 
 __all__ = [
     "ModelConfig",
     "TinyLLM",
+    "TransformerTrunk",
     "generate",
     "KVCache",
     "CacheList",

--- a/model/model.py
+++ b/model/model.py
@@ -9,9 +9,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from model.blocks import TransformerBlock
 from model.config import KVCache, ModelConfig, build_kv_cache
-from model.embeddings import build_positional_encoding
+from model.trunk import TransformerTrunk
 from model.types import LogitsAndLoss, OptionalCacheList
 
 
@@ -29,15 +28,9 @@ class TinyLLM(nn.Module):
         super().__init__()
         self.config = config
 
-        self.token_emb = nn.Embedding(config.vocab_size, config.d_model)
-        self.pos_emb = build_positional_encoding(config)
-        self.emb_dropout = nn.Dropout(config.dropout)
-        self.blocks = nn.ModuleList(
-            [TransformerBlock(config) for _ in range(config.n_layers)]
-        )
-        self.ln_final = nn.LayerNorm(config.d_model)
+        self.trunk = TransformerTrunk(config)
         self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
-        self.lm_head.weight = self.token_emb.weight  # weight tying
+        self.lm_head.weight = self.trunk.token_emb.weight  # weight tying
 
         self._init_weights()
         n = sum(p.numel() for p in self.parameters())
@@ -70,19 +63,8 @@ class TinyLLM(nn.Module):
         caches: OptionalCacheList = None,
         start_pos: int = 0,
     ) -> LogitsAndLoss:
-        B, T = input_ids.shape
-        assert (
-            T + start_pos <= self.config.context_length
-        ), f"Total position {T + start_pos} exceeds context_length {self.config.context_length}"
-
-        x = self.emb_dropout(
-            self.token_emb(input_ids) + self.pos_emb(input_ids, start_pos)
-        )
-
-        for i, block in enumerate(self.blocks):
-            x = block(x, cache=caches[i] if caches is not None else None)
-
-        logits = self.lm_head(self.ln_final(x))
+        x = self.trunk(input_ids, caches=caches, start_pos=start_pos)
+        logits = self.lm_head(x)
 
         loss = None
         if targets is not None:

--- a/model/test_model.py
+++ b/model/test_model.py
@@ -24,6 +24,14 @@ def main() -> None:
     model = TinyLLM(cfg)
     model.eval()
 
+    # Trunk contract: RewardModel/ActorCritic will reuse TransformerTrunk and load
+    # these exact `trunk.*` keys from a TinyLLM checkpoint.
+    assert hasattr(model, "trunk"), "TinyLLM must expose a `trunk` submodule"
+    assert any(k.startswith("trunk.") for k in model.state_dict()), (
+        "state_dict keys must be prefixed with 'trunk.'"
+    )
+    print("Trunk contract OK ✓")
+
     # Forward pass
     x = torch.randint(0, cfg.vocab_size, (2, 64))
     logits, loss = model(x, targets=x)

--- a/model/trunk.py
+++ b/model/trunk.py
@@ -1,0 +1,51 @@
+"""TransformerTrunk: shared token/pos embeddings + blocks + final norm, no LM head.
+
+Reused by TinyLLM (adds lm_head), and later by RewardModel/ActorCritic (add different heads)
+so all three load the exact same `trunk.*` state-dict keys from one checkpoint lineage.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from model.blocks import TransformerBlock
+from model.config import ModelConfig
+from model.embeddings import build_positional_encoding
+from model.types import OptionalCacheList
+
+
+class TransformerTrunk(nn.Module):
+    """token_emb + pos_emb -> emb_dropout -> blocks -> ln_final. Returns hidden states (B, T, C)."""
+
+    def __init__(self, config: ModelConfig) -> None:
+        super().__init__()
+        self.config = config
+
+        self.token_emb = nn.Embedding(config.vocab_size, config.d_model)
+        self.pos_emb = build_positional_encoding(config)
+        self.emb_dropout = nn.Dropout(config.dropout)
+        self.blocks = nn.ModuleList(
+            [TransformerBlock(config) for _ in range(config.n_layers)]
+        )
+        self.ln_final = nn.LayerNorm(config.d_model)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        caches: OptionalCacheList = None,
+        start_pos: int = 0,
+    ) -> torch.Tensor:
+        B, T = input_ids.shape
+        assert (
+            T + start_pos <= self.config.context_length
+        ), f"Total position {T + start_pos} exceeds context_length {self.config.context_length}"
+
+        x = self.emb_dropout(
+            self.token_emb(input_ids) + self.pos_emb(input_ids, start_pos)
+        )
+
+        for i, block in enumerate(self.blocks):
+            x = block(x, cache=caches[i] if caches is not None else None)
+
+        return self.ln_final(x)

--- a/prepare_pipeline_data.py
+++ b/prepare_pipeline_data.py
@@ -1,0 +1,346 @@
+"""
+Stage 0 — Data & tokenizer prep for the full pretrain -> SFT -> reasoning -> reward model -> PPO pipeline.
+
+Downloads Alpaca, GSM8K, and Anthropic hh-rlhf (helpful-base), builds the per-stage dataset files, trains
+the ONE shared BPE tokenizer on the concatenation of all of them, and builds the plain-text corpus Stage 1
+(pretrain.py) trains on. Run once; every later stage resumes from files this script produces.
+
+USAGE:
+    python prepare_pipeline_data.py
+
+Outputs:
+    data/raw/{alpaca_data.json, gsm8k_train.jsonl, gsm8k_test.jsonl, hh_train.jsonl, hh_test.jsonl}
+    data/sft_dataset.json         — Alpaca subsample + existing tinyllm_dataset.json, {question, answer}
+    data/reasoning_dataset.json   — GSM8K CoT, {question, reasoning, answer}
+    data/preference_dataset.json  — hh-rlhf single-turn pairs, {prompt, chosen, rejected}
+    data/raw_text/corpus.txt      — plain-text corpus for Stage 1 unsupervised pretraining
+    checkpoints/tokenizer.json    — shared BPE tokenizer, trained once, reused by every later stage
+"""
+
+import argparse
+import gzip
+import json
+import os
+import random
+import re
+import urllib.request
+from dataclasses import dataclass
+
+from data_utils import QA_TEMPLATE
+from tokenizer import BPETokenizer
+
+CALC_ANNOTATION_RE = re.compile(r"<<[^>]*>>")
+
+RAW_URLS = {
+    "alpaca_data.json": "https://raw.githubusercontent.com/tatsu-lab/stanford_alpaca/main/alpaca_data.json",
+    "gsm8k_train.jsonl": "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/train.jsonl",
+    "gsm8k_test.jsonl": "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl",
+    "hh_train.jsonl.gz": "https://huggingface.co/datasets/Anthropic/hh-rlhf/resolve/main/helpful-base/train.jsonl.gz",
+    "hh_test.jsonl.gz": "https://huggingface.co/datasets/Anthropic/hh-rlhf/resolve/main/helpful-base/test.jsonl.gz",
+}
+
+REASONING_TEMPLATE = "<BOS> Question: {question}\n<THINK> {reasoning} </THINK>\nAnswer: {answer} <EOS>"
+# Same template the reward model / PPO policy will use in Stage 4-5, so the tokenizer already
+# covers that surface form.
+PREFERENCE_TEMPLATE = "<BOS> Question: {prompt}\nAnswer: {response} <EOS>"
+
+
+@dataclass
+class PipelineDataConfig:
+    data_dir: str = "data"
+    raw_dir: str = "data/raw"
+    corpus_dir: str = "data/raw_text"
+    tokenizer_path: str = "checkpoints/tokenizer.json"
+    existing_sft_path: str = "data/tinyllm_dataset.json"
+
+    vocab_size: int = 12_000
+    context_length: int = 384
+
+    sft_subsample: int = 5_000
+    preference_subsample: int = 8_000
+    seed: int = 42
+
+
+# ---------------------------------------------------------------------------
+# Step 1: download
+# ---------------------------------------------------------------------------
+
+
+def download_file(url: str, path: str) -> None:
+    if os.path.exists(path):
+        print(f"  [skip] {path} already exists")
+        return
+    print(f"  Downloading {url}")
+    urllib.request.urlretrieve(url, path)
+    print(f"    -> {path} ({os.path.getsize(path) / 1e6:.1f} MB)")
+
+
+def gunzip(src: str, dst: str) -> None:
+    if os.path.exists(dst):
+        print(f"  [skip] {dst} already exists")
+        return
+    with gzip.open(src, "rb") as f_in, open(dst, "wb") as f_out:
+        f_out.write(f_in.read())
+    print(f"    gunzipped -> {dst}")
+
+
+def download_all(cfg: PipelineDataConfig) -> dict[str, str]:
+    print("Step 1: downloading raw datasets")
+    os.makedirs(cfg.raw_dir, exist_ok=True)
+    paths = {}
+    for filename, url in RAW_URLS.items():
+        path = os.path.join(cfg.raw_dir, filename)
+        download_file(url, path)
+        paths[filename] = path
+
+    hh_train_gz, hh_test_gz = paths["hh_train.jsonl.gz"], paths["hh_test.jsonl.gz"]
+    hh_train = hh_train_gz[: -len(".gz")]
+    hh_test = hh_test_gz[: -len(".gz")]
+    gunzip(hh_train_gz, hh_train)
+    gunzip(hh_test_gz, hh_test)
+    paths["hh_train.jsonl"] = hh_train
+    paths["hh_test.jsonl"] = hh_test
+    return paths
+
+
+def read_jsonl(path: str) -> list[dict]:
+    rows = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Alpaca -> SFT set
+# ---------------------------------------------------------------------------
+
+
+def build_sft_dataset(cfg: PipelineDataConfig, alpaca_path: str) -> list[dict]:
+    print("Step 2: building SFT dataset from Alpaca")
+    with open(alpaca_path, "r", encoding="utf-8") as f:
+        alpaca = json.load(f)
+
+    rng = random.Random(cfg.seed)
+    sample = rng.sample(alpaca, min(cfg.sft_subsample, len(alpaca)))
+
+    pairs = []
+    for row in sample:
+        question = row["instruction"].strip()
+        if row.get("input"):
+            question += "\n" + row["input"].strip()
+        pairs.append({"question": question, "answer": row["output"].strip()})
+
+    with open(cfg.existing_sft_path, "r", encoding="utf-8") as f:
+        existing = json.load(f)
+    existing_pairs = [{"question": r["question"], "answer": r["answer"]} for r in existing]
+
+    dataset = existing_pairs + pairs
+    out_path = os.path.join(cfg.data_dir, "sft_dataset.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(dataset, f, ensure_ascii=False, indent=2)
+    print(
+        f"  Alpaca sampled: {len(pairs):,}  +  existing: {len(existing_pairs):,}"
+        f"  =  {len(dataset):,} total -> {out_path}"
+    )
+    return dataset
+
+
+# ---------------------------------------------------------------------------
+# Step 3: GSM8K -> reasoning set
+# ---------------------------------------------------------------------------
+
+
+def build_reasoning_dataset(cfg: PipelineDataConfig, gsm8k_train_path: str) -> list[dict]:
+    print("Step 3: building reasoning dataset from GSM8K")
+    rows = read_jsonl(gsm8k_train_path)
+
+    examples = []
+    for row in rows:
+        clean_answer = CALC_ANNOTATION_RE.sub("", row["answer"])
+        if "\n#### " not in clean_answer:
+            continue
+        reasoning, final_number = clean_answer.split("\n#### ", 1)
+        examples.append(
+            {
+                "question": row["question"].strip(),
+                "reasoning": reasoning.strip(),
+                "answer": final_number.strip(),
+            }
+        )
+
+    out_path = os.path.join(cfg.data_dir, "reasoning_dataset.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(examples, f, ensure_ascii=False, indent=2)
+    print(f"  GSM8K rendered: {len(examples):,} examples (pre length-filter) -> {out_path}")
+    return examples
+
+
+def filter_reasoning_by_length(
+    cfg: PipelineDataConfig, examples: list[dict], tokenizer: BPETokenizer
+) -> list[dict]:
+    print("Step 6: re-filtering reasoning dataset by tokenized length")
+    kept = []
+    for ex in examples:
+        rendered = REASONING_TEMPLATE.format(**ex)
+        if len(tokenizer.encode(rendered)) <= cfg.context_length:
+            kept.append(ex)
+
+    out_path = os.path.join(cfg.data_dir, "reasoning_dataset.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(kept, f, ensure_ascii=False, indent=2)
+    print(
+        f"  Kept {len(kept):,}/{len(examples):,} examples within context_length={cfg.context_length}"
+        f" -> {out_path}"
+    )
+    return kept
+
+
+# ---------------------------------------------------------------------------
+# Step 4: hh-rlhf -> preference set
+# ---------------------------------------------------------------------------
+
+
+def _parse_single_turn(transcript: str) -> tuple[str, str] | None:
+    """Return (human_question, assistant_reply) if transcript is exactly one turn, else None."""
+    if transcript.count("\n\nHuman:") != 1 or transcript.count("\n\nAssistant:") != 1:
+        return None
+    _, rest = transcript.split("\n\nHuman:", 1)
+    question, reply = rest.split("\n\nAssistant:", 1)
+    return question.strip(), reply.strip()
+
+
+def build_preference_dataset(cfg: PipelineDataConfig, hh_train_path: str) -> list[dict]:
+    print("Step 4: building preference dataset from hh-rlhf helpful-base")
+    rows = read_jsonl(hh_train_path)
+
+    pairs = []
+    for row in rows:
+        chosen_parsed = _parse_single_turn(row["chosen"])
+        rejected_parsed = _parse_single_turn(row["rejected"])
+        if chosen_parsed is None or rejected_parsed is None:
+            continue
+        prompt, chosen_reply = chosen_parsed
+        rejected_prompt, rejected_reply = rejected_parsed
+        if prompt != rejected_prompt:
+            continue
+        pairs.append({"prompt": prompt, "chosen": chosen_reply, "rejected": rejected_reply})
+
+    print(f"  Single-turn pairs available: {len(pairs):,}")
+    rng = random.Random(cfg.seed)
+    if len(pairs) > cfg.preference_subsample:
+        pairs = rng.sample(pairs, cfg.preference_subsample)
+
+    out_path = os.path.join(cfg.data_dir, "preference_dataset.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(pairs, f, ensure_ascii=False, indent=2)
+    print(f"  Kept: {len(pairs):,} pairs -> {out_path}")
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Step 5: train shared tokenizer on the concatenation of all rendered text
+# ---------------------------------------------------------------------------
+
+
+def render_sft(pairs: list[dict]) -> list[str]:
+    return [QA_TEMPLATE.format(question=p["question"], answer=p["answer"]) for p in pairs]
+
+
+def render_reasoning(examples: list[dict]) -> list[str]:
+    return [REASONING_TEMPLATE.format(**ex) for ex in examples]
+
+
+def render_preference(pairs: list[dict]) -> list[str]:
+    rendered = []
+    for p in pairs:
+        rendered.append(PREFERENCE_TEMPLATE.format(prompt=p["prompt"], response=p["chosen"]))
+        rendered.append(PREFERENCE_TEMPLATE.format(prompt=p["prompt"], response=p["rejected"]))
+    return rendered
+
+
+def train_shared_tokenizer(
+    cfg: PipelineDataConfig,
+    sft_pairs: list[dict],
+    reasoning_examples: list[dict],
+    preference_pairs: list[dict],
+) -> BPETokenizer:
+    print("Step 5: training shared BPE tokenizer on all 3 corpora")
+    all_text = "\n".join(
+        render_sft(sft_pairs) + render_reasoning(reasoning_examples) + render_preference(preference_pairs)
+    )
+    tok = BPETokenizer()
+    tok.train(all_text, vocab_size=cfg.vocab_size, verbose=True)
+    os.makedirs(os.path.dirname(cfg.tokenizer_path) or ".", exist_ok=True)
+    tok.save(cfg.tokenizer_path)
+    return tok
+
+
+# ---------------------------------------------------------------------------
+# Step 7: plain-text corpus for Stage 1 pretraining
+# ---------------------------------------------------------------------------
+
+
+def build_pretrain_corpus(cfg: PipelineDataConfig, alpaca_path: str, gsm8k_train_path: str) -> str:
+    print("Step 7: building plain-text corpus for Stage 1 pretraining")
+    with open(alpaca_path, "r", encoding="utf-8") as f:
+        alpaca = json.load(f)
+    gsm8k = read_jsonl(gsm8k_train_path)
+
+    chunks = []
+    for row in alpaca:
+        text = row["instruction"].strip()
+        if row.get("input"):
+            text += "\n" + row["input"].strip()
+        text += "\n" + row["output"].strip()
+        chunks.append(text)
+
+    for row in gsm8k:
+        clean_answer = CALC_ANNOTATION_RE.sub("", row["answer"]).strip()
+        chunks.append(row["question"].strip() + "\n" + clean_answer)
+
+    corpus = "\n\n".join(chunks)
+    os.makedirs(cfg.corpus_dir, exist_ok=True)
+    out_path = os.path.join(cfg.corpus_dir, "corpus.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(corpus)
+    print(
+        f"  Corpus: {len(chunks):,} examples, {len(corpus):,} chars -> {out_path}"
+    )
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(cfg: PipelineDataConfig) -> None:
+    raw_paths = download_all(cfg)
+
+    sft_pairs = build_sft_dataset(cfg, raw_paths["alpaca_data.json"])
+    reasoning_examples = build_reasoning_dataset(cfg, raw_paths["gsm8k_train.jsonl"])
+    preference_pairs = build_preference_dataset(cfg, raw_paths["hh_train.jsonl"])
+
+    tokenizer = train_shared_tokenizer(cfg, sft_pairs, reasoning_examples, preference_pairs)
+    reasoning_examples = filter_reasoning_by_length(cfg, reasoning_examples, tokenizer)
+
+    build_pretrain_corpus(cfg, raw_paths["alpaca_data.json"], raw_paths["gsm8k_train.jsonl"])
+
+    print("\nDone.")
+    print(f"  SFT dataset        : {len(sft_pairs):,} examples")
+    print(f"  Reasoning dataset  : {len(reasoning_examples):,} examples")
+    print(f"  Preference dataset : {len(preference_pairs):,} pairs")
+    print(f"  Tokenizer vocab    : {tokenizer.vocab_size}")
+    print("\nNext: python pretokenize.py --corpus_dir data/raw_text --tokenizer_path checkpoints/tokenizer.json --out_dir data/tokenized")
+
+
+if __name__ == "__main__":
+    default = PipelineDataConfig()
+    p = argparse.ArgumentParser()
+    for k, v in default.__dict__.items():
+        p.add_argument(f"--{k}", type=type(v), default=v)
+    args = p.parse_args()
+    main(PipelineDataConfig(**vars(args)))

--- a/pretrain.py
+++ b/pretrain.py
@@ -317,6 +317,7 @@ def evaluate(model, val_loader, eval_iters, device, ctx):
 
 def save_checkpoint(model, optimizer, step, val_loss, config, model_config, path):
     raw = model.module if isinstance(model, DDP) else model
+    raw = raw._orig_mod if hasattr(raw, "_orig_mod") else raw  # unwrap torch.compile
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     torch.save(
         {

--- a/tokenizer/constants.py
+++ b/tokenizer/constants.py
@@ -6,4 +6,6 @@ Shared constants for the BPE tokenizer.
 WORD_BOUNDARY = "▁"
 
 # Special tokens — order matters: indices 0-3 are reserved for these.
-SPECIAL_TOKENS: list[str] = ["<PAD>", "<UNK>", "<BOS>", "<EOS>"]
+# <THINK>/</THINK> (indices 4-5) wrap chain-of-thought reasoning traces so they get
+# dedicated tokens instead of being fragmented by BPE.
+SPECIAL_TOKENS: list[str] = ["<PAD>", "<UNK>", "<BOS>", "<EOS>", "<THINK>", "</THINK>"]

--- a/tokenizer/tokenizer.py
+++ b/tokenizer/tokenizer.py
@@ -34,6 +34,7 @@ class BPETokenizer:
         self.encoder: dict[str, int] = {}  # token -> id
         self.decoder: dict[int, str] = {}  # id -> token
         self.merges: list[tuple[str, str]] = []  # ordered merge rules
+        self.merge_ranks: dict[tuple[str, str], int] = {}  # merge -> position in self.merges
         self.vocab_size: int = 0
 
     # ------------------------------------------------------------------
@@ -127,6 +128,7 @@ class BPETokenizer:
 
         self.vocab_size = len(self.encoder)
         self.decoder = {v: k for k, v in self.encoder.items()}
+        self.merge_ranks = {pair: i for i, pair in enumerate(self.merges)}
 
         if verbose:
             print(f"Training complete. Final vocab size: {self.vocab_size}")
@@ -136,10 +138,29 @@ class BPETokenizer:
     # ------------------------------------------------------------------
 
     def _tokenize_word(self, word: str) -> list[str]:
-        """Apply learned BPE merges to a single word."""
+        """Apply learned BPE merges to a single word.
+
+        Rather than scanning the full ordered merge list (which was learned once over the whole
+        corpus and is only sparsely relevant to any one word), repeatedly find the adjacent pair
+        with the lowest rank (earliest-learned) that's actually present in the word and merge it.
+        This produces exactly the same result as applying the merges in order — a rank-N merge
+        can only ever create a pair for a rank-N+1 merge, so picking the lowest-rank pair present
+        at each step reproduces the same merge sequence — just skipping the merges that don't
+        apply to this word instead of checking each one explicitly.
+        """
         symbols = list(WORD_BOUNDARY + word)
 
-        for left, right in self.merges:
+        while len(symbols) > 1:
+            ranked_pairs = (
+                (self.merge_ranks[pair], pair)
+                for pair in zip(symbols, symbols[1:])
+                if pair in self.merge_ranks
+            )
+            best = min(ranked_pairs, default=None)
+            if best is None:
+                break
+            left, right = best[1]
+
             i = 0
             new_symbols: list[str] = []
             while i < len(symbols):
@@ -235,4 +256,5 @@ class BPETokenizer:
         tok.merges = [tuple(m) for m in data["merges"]]
         tok.vocab_size = data["vocab_size"]
         tok.decoder = {int(v): k for k, v in tok.encoder.items()}
+        tok.merge_ranks = {pair: i for i, pair in enumerate(tok.merges)}
         return tok


### PR DESCRIPTION
## Summary

Closes #11. First slice of the full pipeline in `PLAN.md` (pretrain -> instruction-SFT -> reasoning SFT -> reward model -> PPO RLHF).

- **Architecture**: extract `model/trunk.py::TransformerTrunk` (token/pos embeddings, blocks, final norm) out of `TinyLLM`, which becomes a thin wrapper (`trunk` + `lm_head`). Done now, before any checkpoint in this pipeline exists, so the Reward Model / PPO ActorCritic can later load the same `trunk.*` keys without a migration step. Forward signature/behavior unchanged.
- **Tokenizer**: add `<THINK>`/`</THINK>` special tokens (for the upcoming reasoning-SFT stage) and train one shared BPE tokenizer (vocab_size=12000) on the concatenation of all 3 corpora used across the whole pipeline (Alpaca, GSM8K, hh-rlhf `helpful-base`), so vocab never has to change again after this pretrain checkpoint. Also fixed a real perf bug found along the way: `encode()` scanned the *entire* ordered merge list per word, which made tokenizing this corpus take ~75 min; switched to the standard rank-based merge technique (same GPT-2 uses) — verified byte-identical output against the old implementation on 3000 real words, now ~17s.
- **Stage 0 data prep** (`prepare_pipeline_data.py`, new): downloads Alpaca/GSM8K/hh-rlhf, builds `data/sft_dataset.json` (5,050 examples), `data/reasoning_dataset.json` (7,472 CoT examples w/ `<THINK>` tags), `data/preference_dataset.json` (8,000 single-turn chosen/rejected pairs), and `data/raw_text/corpus.txt` (22M-char plain-text corpus for unsupervised pretraining).
- **Stage 1**: ran existing `pretokenize.py` + `pretrain.py` (unmodified aside from one bug fix below) on the new corpus with the "Small" config (`d_model=512, n_heads=8, n_layers=8, d_ff=1024, context_length=384, vocab_size=12000`) for 3000 iters. 23.15M params. Val loss bottomed at 4.38 (iter 1000, `best.pt`) then rose to 5.09 by iter 3000 (`pretrain_final.pt`) — genuine overfitting on this small corpus, documented rather than hidden.
- **Bug fix**: `pretrain.py`'s `save_checkpoint` only unwrapped DDP, not `torch.compile`'s `OptimizedModule` — on a plain single-GPU run (compile=True by default) every saved key got an `_orig_mod.` prefix nothing downstream expects. Fixed, and patched the already-saved checkpoints in place.
- `inference.py`: added `--tokenizer_path` override, since pretrain.py checkpoints carry `pretrain_config` (not `train_config`), so the old default silently pointed at the wrong tokenizer.

## Out of scope (future PRs)
SFT/reasoning/reward-model/PPO training scripts, and `docs/` + the HTML summary artifact.

## Test plan
- [x] `pytest tokenizer/test_tokenizer.py` — 17 passed
- [x] `python -m model.test_model` — trunk contract + forward + generation OK
- [x] `prepare_pipeline_data.py` run end-to-end; spot-checked rendered SFT/reasoning/preference examples and tokenizer round-trip
- [x] Full Stage 1 training run (3000 iters); verified with `inference.py` on both `best.pt` and `pretrain_final.pt` — base model produces plausible English/Alpaca-style structure but (correctly, expected at this stage) cannot yet answer questions, since it was never shown Q&A structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)