### PR TITLE
Enrich pretrain data with WikiText-2, Dolly SFT, checkpoint improvements

### DIFF
--- a/prepare_pipeline_data.py
+++ b/prepare_pipeline_data.py
@@ -1,16 +1,23 @@
 """
 Stage 0 — Data & tokenizer prep for the full pretrain -> SFT -> reasoning -> reward model -> PPO pipeline.
 
-Downloads Alpaca, GSM8K, and Anthropic hh-rlhf (helpful-base), builds the per-stage dataset files, trains
-the ONE shared BPE tokenizer on the concatenation of all of them, and builds the plain-text corpus Stage 1
-(pretrain.py) trains on. Run once; every later stage resumes from files this script produces.
+Downloads Alpaca, Dolly-15k, GSM8K, and Anthropic hh-rlhf (helpful-base), builds the per-stage dataset
+files, trains the ONE shared BPE tokenizer on the concatenation of Alpaca+GSM8K+hh-rlhf, and builds the
+plain-text corpus Stage 1 (pretrain.py) trains on. Run once; every later stage resumes from files this
+script produces.
+
+Re-running is safe and cheap: downloads are skipped if already present, and by default the tokenizer is
+loaded rather than retrained if checkpoints/tokenizer.json already exists (pass --force_retrain_tokenizer
+to override) — so e.g. changing the SFT mix doesn't invalidate an existing pretrain checkpoint's vocab.
+Dolly is intentionally excluded from tokenizer training for this reason; it's plain English in the same
+register as Alpaca, so it encodes fine through the existing vocab.
 
 USAGE:
     python prepare_pipeline_data.py
 
 Outputs:
-    data/raw/{alpaca_data.json, gsm8k_train.jsonl, gsm8k_test.jsonl, hh_train.jsonl, hh_test.jsonl}
-    data/sft_dataset.json         — Alpaca subsample + existing tinyllm_dataset.json, {question, answer}
+    data/raw/{alpaca_data.json, dolly_15k.jsonl, gsm8k_train.jsonl, gsm8k_test.jsonl, hh_train.jsonl, hh_test.jsonl}
+    data/sft_dataset.json         — existing tinyllm_dataset.json + Alpaca subsample + Dolly-15k, {question, answer}
     data/reasoning_dataset.json   — GSM8K CoT, {question, reasoning, answer}
     data/preference_dataset.json  — hh-rlhf single-turn pairs, {prompt, chosen, rejected}
     data/raw_text/corpus.txt      — plain-text corpus for Stage 1 unsupervised pretraining
@@ -33,6 +40,7 @@ CALC_ANNOTATION_RE = re.compile(r"<<[^>]*>>")
 
 RAW_URLS = {
     "alpaca_data.json": "https://raw.githubusercontent.com/tatsu-lab/stanford_alpaca/main/alpaca_data.json",
+    "dolly_15k.jsonl": "https://huggingface.co/datasets/databricks/databricks-dolly-15k/resolve/main/databricks-dolly-15k.jsonl",
     "gsm8k_train.jsonl": "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/train.jsonl",
     "gsm8k_test.jsonl": "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl",
     "hh_train.jsonl.gz": "https://huggingface.co/datasets/Anthropic/hh-rlhf/resolve/main/helpful-base/train.jsonl.gz",
@@ -59,6 +67,7 @@ class PipelineDataConfig:
     sft_subsample: int = 5_000
     preference_subsample: int = 8_000
     seed: int = 42
+    force_retrain_tokenizer: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -114,36 +123,43 @@ def read_jsonl(path: str) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Step 2: Alpaca -> SFT set
+# Step 2: Alpaca + Dolly-15k -> SFT set
 # ---------------------------------------------------------------------------
 
 
-def build_sft_dataset(cfg: PipelineDataConfig, alpaca_path: str) -> list[dict]:
-    print("Step 2: building SFT dataset from Alpaca")
+def build_sft_dataset(cfg: PipelineDataConfig, alpaca_path: str, dolly_path: str) -> list[dict]:
+    print("Step 2: building SFT dataset from Alpaca + Dolly-15k")
     with open(alpaca_path, "r", encoding="utf-8") as f:
         alpaca = json.load(f)
 
     rng = random.Random(cfg.seed)
-    sample = rng.sample(alpaca, min(cfg.sft_subsample, len(alpaca)))
+    alpaca_sample = rng.sample(alpaca, min(cfg.sft_subsample, len(alpaca)))
 
-    pairs = []
-    for row in sample:
+    alpaca_pairs = []
+    for row in alpaca_sample:
         question = row["instruction"].strip()
         if row.get("input"):
             question += "\n" + row["input"].strip()
-        pairs.append({"question": question, "answer": row["output"].strip()})
+        alpaca_pairs.append({"question": question, "answer": row["output"].strip()})
+
+    dolly_pairs = []
+    for row in read_jsonl(dolly_path):
+        question = row["instruction"].strip()
+        if row.get("context"):
+            question += "\n" + row["context"].strip()
+        dolly_pairs.append({"question": question, "answer": row["response"].strip()})
 
     with open(cfg.existing_sft_path, "r", encoding="utf-8") as f:
         existing = json.load(f)
     existing_pairs = [{"question": r["question"], "answer": r["answer"]} for r in existing]
 
-    dataset = existing_pairs + pairs
+    dataset = existing_pairs + alpaca_pairs + dolly_pairs
     out_path = os.path.join(cfg.data_dir, "sft_dataset.json")
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(dataset, f, ensure_ascii=False, indent=2)
     print(
-        f"  Alpaca sampled: {len(pairs):,}  +  existing: {len(existing_pairs):,}"
-        f"  =  {len(dataset):,} total -> {out_path}"
+        f"  Identity: {len(existing_pairs):,}  +  Alpaca: {len(alpaca_pairs):,}"
+        f"  +  Dolly: {len(dolly_pairs):,}  =  {len(dataset):,} total -> {out_path}"
     )
     return dataset
 
@@ -267,6 +283,10 @@ def train_shared_tokenizer(
     reasoning_examples: list[dict],
     preference_pairs: list[dict],
 ) -> BPETokenizer:
+    if os.path.exists(cfg.tokenizer_path) and not cfg.force_retrain_tokenizer:
+        print(f"Step 5: loading existing tokenizer from {cfg.tokenizer_path} (pass --force_retrain_tokenizer to retrain)")
+        return BPETokenizer.load(cfg.tokenizer_path)
+
     print("Step 5: training shared BPE tokenizer on all 3 corpora")
     all_text = "\n".join(
         render_sft(sft_pairs) + render_reasoning(reasoning_examples) + render_preference(preference_pairs)
@@ -320,7 +340,7 @@ def build_pretrain_corpus(cfg: PipelineDataConfig, alpaca_path: str, gsm8k_train
 def main(cfg: PipelineDataConfig) -> None:
     raw_paths = download_all(cfg)
 
-    sft_pairs = build_sft_dataset(cfg, raw_paths["alpaca_data.json"])
+    sft_pairs = build_sft_dataset(cfg, raw_paths["alpaca_data.json"], raw_paths["dolly_15k.jsonl"])
     reasoning_examples = build_reasoning_dataset(cfg, raw_paths["gsm8k_train.jsonl"])
     preference_pairs = build_preference_dataset(cfg, raw_paths["hh_train.jsonl"])
 
@@ -341,6 +361,9 @@ if __name__ == "__main__":
     default = PipelineDataConfig()
     p = argparse.ArgumentParser()
     for k, v in default.__dict__.items():
-        p.add_argument(f"--{k}", type=type(v), default=v)
+        if isinstance(v, bool):
+            p.add_argument(f"--{k}", default=v, action="store_true")
+        else:
+            p.add_argument(f"--{k}", type=type(v), default=v)
     args = p.parse_args()
     main(PipelineDataConfig(**vars(args)))

--- a/prepare_pipeline_data.py
+++ b/prepare_pipeline_data.py
@@ -1,26 +1,30 @@
 """
 Stage 0 — Data & tokenizer prep for the full pretrain -> SFT -> reasoning -> reward model -> PPO pipeline.
 
-Downloads Alpaca, Dolly-15k, GSM8K, and Anthropic hh-rlhf (helpful-base), builds the per-stage dataset
-files, trains the ONE shared BPE tokenizer on the concatenation of Alpaca+GSM8K+hh-rlhf, and builds the
-plain-text corpus Stage 1 (pretrain.py) trains on. Run once; every later stage resumes from files this
-script produces.
+Downloads Alpaca, Dolly-15k, GSM8K, Anthropic hh-rlhf (helpful-base), and WikiText-2 (real Wikipedia
+prose, for actual world-knowledge exposure during pretraining — Alpaca+GSM8K text alone has essentially
+none), builds the per-stage dataset files, trains the ONE shared BPE tokenizer, and builds the plain-text
+corpus Stage 1 (pretrain.py) trains on. Run once; every later stage resumes from files this script produces.
 
 Re-running is safe and cheap: downloads are skipped if already present, and by default the tokenizer is
 loaded rather than retrained if checkpoints/tokenizer.json already exists (pass --force_retrain_tokenizer
 to override) — so e.g. changing the SFT mix doesn't invalidate an existing pretrain checkpoint's vocab.
 Dolly is intentionally excluded from tokenizer training for this reason; it's plain English in the same
-register as Alpaca, so it encodes fine through the existing vocab.
+register as Alpaca, so it encodes fine through the existing vocab. WikiText IS included in tokenizer
+training when --force_retrain_tokenizer is passed, since encyclopedic proper nouns/terms benefit from
+dedicated subword coverage and (unlike the Dolly case) there's no existing checkpoint to protect when
+you're intentionally retraining the tokenizer.
 
 USAGE:
-    python prepare_pipeline_data.py
+    python prepare_pipeline_data.py --force_retrain_tokenizer   # first run, or to fold in a new corpus
 
 Outputs:
-    data/raw/{alpaca_data.json, dolly_15k.jsonl, gsm8k_train.jsonl, gsm8k_test.jsonl, hh_train.jsonl, hh_test.jsonl}
+    data/raw/{alpaca_data.json, dolly_15k.jsonl, gsm8k_train.jsonl, gsm8k_test.jsonl, hh_train.jsonl,
+              hh_test.jsonl, wikitext2_train.txt}
     data/sft_dataset.json         — existing tinyllm_dataset.json + Alpaca subsample + Dolly-15k, {question, answer}
     data/reasoning_dataset.json   — GSM8K CoT, {question, reasoning, answer}
     data/preference_dataset.json  — hh-rlhf single-turn pairs, {prompt, chosen, rejected}
-    data/raw_text/corpus.txt      — plain-text corpus for Stage 1 unsupervised pretraining
+    data/raw_text/corpus.txt      — plain-text corpus (Alpaca+GSM8K+WikiText-2) for Stage 1 pretraining
     checkpoints/tokenizer.json    — shared BPE tokenizer, trained once, reused by every later stage
 """
 
@@ -37,6 +41,8 @@ from data_utils import QA_TEMPLATE
 from tokenizer import BPETokenizer
 
 CALC_ANNOTATION_RE = re.compile(r"<<[^>]*>>")
+WIKITEXT_ARTIFACT_RE = re.compile(r"\s+([.,!?;:)])")
+WIKITEXT_OPEN_PAREN_RE = re.compile(r"\(\s+")
 
 RAW_URLS = {
     "alpaca_data.json": "https://raw.githubusercontent.com/tatsu-lab/stanford_alpaca/main/alpaca_data.json",
@@ -45,6 +51,7 @@ RAW_URLS = {
     "gsm8k_test.jsonl": "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl",
     "hh_train.jsonl.gz": "https://huggingface.co/datasets/Anthropic/hh-rlhf/resolve/main/helpful-base/train.jsonl.gz",
     "hh_test.jsonl.gz": "https://huggingface.co/datasets/Anthropic/hh-rlhf/resolve/main/helpful-base/test.jsonl.gz",
+    "wikitext2_train.txt": "https://raw.githubusercontent.com/pytorch/examples/main/word_language_model/data/wikitext-2/train.txt",
 }
 
 REASONING_TEMPLATE = "<BOS> Question: {question}\n<THINK> {reasoning} </THINK>\nAnswer: {answer} <EOS>"
@@ -120,6 +127,28 @@ def read_jsonl(path: str) -> list[dict]:
             if line:
                 rows.append(json.loads(line))
     return rows
+
+
+def clean_wikitext(text: str) -> str:
+    """Undo WikiText's tokenization artifacts: space-separated punctuation, "@-@"-style
+    escaped hyphens/periods/commas, and <unk> rare-word placeholders."""
+    text = text.replace("<unk>", " ")
+    text = text.replace(" @-@ ", "-").replace(" @.@ ", ".").replace(" @,@ ", ",")
+    text = WIKITEXT_ARTIFACT_RE.sub(r"\1", text)
+    text = WIKITEXT_OPEN_PAREN_RE.sub("(", text)
+    for suffix in ["'s", "'ll", "'re", "'ve", "'d", "'m", "n't"]:
+        text = text.replace(" " + suffix, suffix)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n\s*\n+", "\n\n", text)
+    text = re.sub(r" *\n *", "\n", text)
+    return text.strip()
+
+
+def load_wikitext_paragraphs(wikitext_path: str) -> list[str]:
+    with open(wikitext_path, "r", encoding="utf-8") as f:
+        raw = f.read()
+    paragraphs = [p.strip() for p in clean_wikitext(raw).split("\n\n")]
+    return [p for p in paragraphs if p and not p.startswith("=")]
 
 
 # ---------------------------------------------------------------------------
@@ -282,14 +311,18 @@ def train_shared_tokenizer(
     sft_pairs: list[dict],
     reasoning_examples: list[dict],
     preference_pairs: list[dict],
+    wikitext_paragraphs: list[str],
 ) -> BPETokenizer:
     if os.path.exists(cfg.tokenizer_path) and not cfg.force_retrain_tokenizer:
         print(f"Step 5: loading existing tokenizer from {cfg.tokenizer_path} (pass --force_retrain_tokenizer to retrain)")
         return BPETokenizer.load(cfg.tokenizer_path)
 
-    print("Step 5: training shared BPE tokenizer on all 3 corpora")
+    print("Step 5: training shared BPE tokenizer on all corpora (incl. WikiText-2)")
     all_text = "\n".join(
-        render_sft(sft_pairs) + render_reasoning(reasoning_examples) + render_preference(preference_pairs)
+        render_sft(sft_pairs)
+        + render_reasoning(reasoning_examples)
+        + render_preference(preference_pairs)
+        + wikitext_paragraphs
     )
     tok = BPETokenizer()
     tok.train(all_text, vocab_size=cfg.vocab_size, verbose=True)
@@ -303,7 +336,12 @@ def train_shared_tokenizer(
 # ---------------------------------------------------------------------------
 
 
-def build_pretrain_corpus(cfg: PipelineDataConfig, alpaca_path: str, gsm8k_train_path: str) -> str:
+def build_pretrain_corpus(
+    cfg: PipelineDataConfig,
+    alpaca_path: str,
+    gsm8k_train_path: str,
+    wikitext_paragraphs: list[str],
+) -> str:
     print("Step 7: building plain-text corpus for Stage 1 pretraining")
     with open(alpaca_path, "r", encoding="utf-8") as f:
         alpaca = json.load(f)
@@ -320,6 +358,8 @@ def build_pretrain_corpus(cfg: PipelineDataConfig, alpaca_path: str, gsm8k_train
     for row in gsm8k:
         clean_answer = CALC_ANNOTATION_RE.sub("", row["answer"]).strip()
         chunks.append(row["question"].strip() + "\n" + clean_answer)
+
+    chunks.extend(wikitext_paragraphs)
 
     corpus = "\n\n".join(chunks)
     os.makedirs(cfg.corpus_dir, exist_ok=True)
@@ -343,11 +383,17 @@ def main(cfg: PipelineDataConfig) -> None:
     sft_pairs = build_sft_dataset(cfg, raw_paths["alpaca_data.json"], raw_paths["dolly_15k.jsonl"])
     reasoning_examples = build_reasoning_dataset(cfg, raw_paths["gsm8k_train.jsonl"])
     preference_pairs = build_preference_dataset(cfg, raw_paths["hh_train.jsonl"])
+    wikitext_paragraphs = load_wikitext_paragraphs(raw_paths["wikitext2_train.txt"])
+    print(f"  WikiText-2: {len(wikitext_paragraphs):,} paragraphs")
 
-    tokenizer = train_shared_tokenizer(cfg, sft_pairs, reasoning_examples, preference_pairs)
+    tokenizer = train_shared_tokenizer(
+        cfg, sft_pairs, reasoning_examples, preference_pairs, wikitext_paragraphs
+    )
     reasoning_examples = filter_reasoning_by_length(cfg, reasoning_examples, tokenizer)
 
-    build_pretrain_corpus(cfg, raw_paths["alpaca_data.json"], raw_paths["gsm8k_train.jsonl"])
+    build_pretrain_corpus(
+        cfg, raw_paths["alpaca_data.json"], raw_paths["gsm8k_train.jsonl"], wikitext_paragraphs
+    )
 
     print("\nDone.")
     print(f"  SFT dataset        : {len(sft_pairs):,} examples")

--- a/train.py
+++ b/train.py
@@ -64,6 +64,7 @@ class TrainConfig:
     # Data
     dataset_path: str = "data/tinyllm_dataset.json"
     data_dir: str = "data"
+    tokenizer_path: str = "data/tokenizer.json"
     vocab_size: int = 8000
     context_length: int = 64
     val_fraction: float = 0.1
@@ -99,6 +100,9 @@ class TrainConfig:
     checkpoint_dir: str = "checkpoints"
     checkpoint_interval: int = 500
     resume_from: str = ""  # path to checkpoint to resume from
+    resume_weights_only: bool = False  # cross-stage init: load weights only, start fresh at iter 0
+    # with no optimizer state, instead of continuing resume_from's own iter count/optimizer
+    # (the latter is only correct when resuming an interrupted run of *this same* stage)
 
     # System
     dtype: str = "bfloat16"  # float32, float16, bfloat16
@@ -229,8 +233,9 @@ def save_checkpoint(
     path: str,
 ):
     """Save training state to disk."""
-    # Unwrap DDP if necessary
+    # Unwrap DDP and torch.compile's OptimizedModule if necessary
     raw_model = model.module if isinstance(model, DDP) else model
+    raw_model = raw_model._orig_mod if hasattr(raw_model, "_orig_mod") else raw_model
     checkpoint = {
         "model_state_dict": raw_model.state_dict(),
         "optimizer_state_dict": optimizer.state_dict(),
@@ -246,9 +251,11 @@ def save_checkpoint(
 def load_checkpoint(path: str, model: nn.Module, optimizer=None):
     """Load checkpoint and return iteration number and saved model config."""
     checkpoint = torch.load(path, map_location="cpu")
+    # Unwrap DDP and torch.compile's OptimizedModule so state dict keys line up regardless
+    # of whether the *target* model is compiled/DDP-wrapped and whether the *saved* one was.
     raw_model = model.module if isinstance(model, DDP) else model
+    raw_model = raw_model._orig_mod if hasattr(raw_model, "_orig_mod") else raw_model
 
-    # Handle checkpoints saved from torch.compile() — strip "_orig_mod." prefix
     state_dict = checkpoint["model_state_dict"]
     if any(k.startswith("_orig_mod.") for k in state_dict):
         state_dict = {k.replace("_orig_mod.", ""): v for k, v in state_dict.items()}
@@ -306,6 +313,7 @@ def train(config: TrainConfig):
         vocab_size=config.vocab_size,
         context_length=config.context_length,
         val_fraction=config.val_fraction,
+        tokenizer_path=config.tokenizer_path,
     )
 
     train_loader = create_dataloader(
@@ -390,7 +398,14 @@ def train(config: TrainConfig):
     # --- Resume from checkpoint ---
     start_iter = 0
     if config.resume_from and os.path.exists(config.resume_from):
-        start_iter, _ = load_checkpoint(config.resume_from, model, optimizer)
+        if config.resume_weights_only:
+            loaded_iter, _ = load_checkpoint(config.resume_from, model, optimizer=None)
+            if master:
+                print(
+                    f"  (weights only — starting fresh at iter 0, ignoring source iter={loaded_iter})"
+                )
+        else:
+            start_iter, _ = load_checkpoint(config.resume_from, model, optimizer)
 
     # --- Training loop ---
     if master:
@@ -403,6 +418,7 @@ def train(config: TrainConfig):
     model.train()
     train_iter = iter(train_loader)
     running_loss = 0.0
+    best_val = float("inf")
     t0 = time.time()
 
     for iter_num in range(start_iter, config.max_iters):
@@ -479,6 +495,18 @@ def train(config: TrainConfig):
         if master and (iter_num + 1) % config.eval_interval == 0:
             val_loss = evaluate(model, val_loader, config.eval_iters, device, ctx)
             print(f"{'>>> VAL':>8} | {lr:>10.2e} | {'':>12} | {val_loss:>10.4f} |")
+
+            if val_loss < best_val:
+                best_val = val_loss
+                save_checkpoint(
+                    model,
+                    optimizer,
+                    iter_num + 1,
+                    val_loss,
+                    config,
+                    model_config,
+                    os.path.join(config.checkpoint_dir, "best.pt"),
+                )
 
             # Save checkpoint
             if (iter_num + 1) % config.checkpoint_interval == 0:


### PR DESCRIPTION
Closes #13

## Summary
- Enrich the SFT dataset with Dolly-15k and make tokenizer training idempotent (skip retrain if `checkpoints/tokenizer.json` exists, unless `--force_retrain_tokenizer` is passed)
- Fold WikiText-2 (real Wikipedia prose) into the pretrain corpus and tokenizer training so the model gets actual world-knowledge exposure, since Alpaca+GSM8K text alone has essentially none
- `train.py`: track and save a `best.pt` checkpoint on lowest val loss, support weights-only cross-stage resume (`resume_weights_only`), and make checkpoint save/load robust to `torch.compile`'s `OptimizedModule` wrapper

## Test plan
- [x] Run `python prepare_pipeline_data.py --force_retrain_tokenizer` and confirm WikiText-2 downloads, cleans, and folds into both the tokenizer training corpus and `data/raw_text/corpus.txt`
- [ ] Run `python prepare_pipeline_data.py` again and confirm it loads the existing tokenizer instead of retraining
- [x] Run `python train.py` and confirm `checkpoints/best.pt` is written/updated on improved val loss
- [x] Run `python train.py --resume_from <ckpt> --resume_weights_only` and confirm it starts fresh at iter 0 using only the loaded weights

🤖 Generated with [Claude Code](https://claude.com/claude-code)
