### PR TITLE
Add optional Weights & Biases logging to pretrain.py and train.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ data/sft_dataset.json
 data/reasoning_dataset.json
 data/preference_dataset.json
 checkpoints/
+
+# Weights & Biases local run logs
+wandb/

--- a/README.md
+++ b/README.md
@@ -233,6 +233,16 @@ torchrun --nproc_per_node=2 train.py \
     --n_layers 8
 ```
 
+### Monitor training with Weights & Biases
+Both `train.py` (SFT) and `pretrain.py` support optional [W&B](https://wandb.ai) logging of train/val
+loss, perplexity, learning rate, tokens/sec, and gradients — off by default, opt in with `--use_wandb`.
+```bash
+pip install wandb
+wandb login
+python train.py --use_wandb --wandb_project tinyllm-sft --wandb_run_name my-run
+python pretrain.py --use_wandb --wandb_project tinyllm-pretrain
+```
+
 ### Generate text
 ```bash
 python generate.py \

--- a/pretrain.py
+++ b/pretrain.py
@@ -14,6 +14,10 @@ HOW TO RUN:
 
     # 4. Resume:
     python pretrain.py --corpus_dir data/tokenized --resume_from checkpoints/pretrain/latest.pt
+
+    # 5. With Weights & Biases logging:
+    pip install wandb && wandb login
+    python pretrain.py --corpus_dir data/tokenized --use_wandb --wandb_project my-project
 """
 
 import argparse
@@ -37,6 +41,11 @@ from torch.utils.data import DataLoader, IterableDataset
 
 from model import ModelConfig, TinyLLM
 from tokenizer import BPETokenizer
+
+try:
+    import wandb
+except ImportError:
+    wandb = None
 
 # ---------------------------------------------------------------------------
 # Config
@@ -78,6 +87,10 @@ class PretrainConfig:
     compile: bool = True
     num_workers: int = 4
     seed: int = 42
+
+    use_wandb: bool = False
+    wandb_project: str = "tinyllm-pretrain"
+    wandb_run_name: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +421,16 @@ def pretrain(config: PretrainConfig):
 
     os.makedirs(config.checkpoint_dir, exist_ok=True)
 
+    if master and config.use_wandb:
+        if wandb is None:
+            raise RuntimeError("use_wandb=True but the `wandb` package is not installed. Run `pip install wandb`.")
+        wandb.init(
+            project=config.wandb_project,
+            name=config.wandb_run_name or None,
+            config={**config.__dict__, **model_config.__dict__},
+        )
+        wandb.watch(raw, log="gradients", log_freq=config.log_interval * 10)
+
     if master:
         eff = config.batch_size * config.grad_accumulation_steps * world_size
         print(
@@ -465,6 +488,16 @@ def pretrain(config: PretrainConfig):
             print(
                 f"{step+1:>8} | {lr:>10.2e} | {avg:>10.4f} | {math.exp(min(avg,20)):>8.1f} | {tok_count/dt:>10,.0f}"
             )
+            if config.use_wandb:
+                wandb.log(
+                    {
+                        "train/loss": avg,
+                        "train/ppl": math.exp(min(avg, 20)),
+                        "train/lr": lr,
+                        "train/tokens_per_sec": tok_count / dt,
+                    },
+                    step=step + 1,
+                )
             running_loss, tok_count, t0 = 0.0, 0, time.perf_counter()
 
         if master and (step + 1) % config.eval_interval == 0:
@@ -472,6 +505,14 @@ def pretrain(config: PretrainConfig):
             print(
                 f"{'VAL':>8} | {lr:>10.2e} | {val_loss:>10.4f} | {math.exp(min(val_loss,20)):>8.1f} |"
             )
+            if config.use_wandb:
+                wandb.log(
+                    {
+                        "val/loss": val_loss,
+                        "val/ppl": math.exp(min(val_loss, 20)),
+                    },
+                    step=step + 1,
+                )
             save_checkpoint(
                 model,
                 optimizer,
@@ -514,6 +555,8 @@ def pretrain(config: PretrainConfig):
             os.path.join(config.checkpoint_dir, "pretrain_final.pt"),
         )
         print("Done. Pass pretrain_final.pt to train.py via --resume_from.")
+        if config.use_wandb:
+            wandb.finish()
 
     if ddp:
         dist.destroy_process_group()

--- a/train.py
+++ b/train.py
@@ -36,6 +36,10 @@ HOW TO RUN:
 
     With custom config:
         torchrun --nproc_per_node=2 train.py --batch_size 16 --max_iters 5000
+
+    With Weights & Biases logging:
+        pip install wandb && wandb login
+        python train.py --use_wandb --wandb_project my-project
 """
 
 import argparse
@@ -53,6 +57,11 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from data_utils import create_dataloader, prepare_custom_data
 from model import ModelConfig, TinyLLM
+
+try:
+    import wandb
+except ImportError:
+    wandb = None
 
 # ---------------------------------------------------------------------------
 # Training Configuration
@@ -108,6 +117,11 @@ class TrainConfig:
     dtype: str = "bfloat16"  # float32, float16, bfloat16
     compile: bool = False  # torch.compile (PyTorch 2.0+, faster but slower startup)
     num_workers: int = 4
+
+    # Monitoring
+    use_wandb: bool = False
+    wandb_project: str = "tinyllm-sft"
+    wandb_run_name: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -407,6 +421,16 @@ def train(config: TrainConfig):
         else:
             start_iter, _ = load_checkpoint(config.resume_from, model, optimizer)
 
+    if master and config.use_wandb:
+        if wandb is None:
+            raise RuntimeError("use_wandb=True but the `wandb` package is not installed. Run `pip install wandb`.")
+        wandb.init(
+            project=config.wandb_project,
+            name=config.wandb_run_name or None,
+            config={**config.__dict__, **model_config.__dict__},
+        )
+        wandb.watch(raw_model, log="gradients", log_freq=config.log_interval * 10)
+
     # --- Training loop ---
     if master:
         print(f"\nStarting training for {config.max_iters} iterations...")
@@ -488,6 +512,16 @@ def train(config: TrainConfig):
                 f"{iter_num+1:>8} | {lr:>10.2e} | {avg_loss:>12.4f} | "
                 f"{'':>10} | {tokens_per_sec:>10,.0f} | {dt:>7.1f}s"
             )
+            if config.use_wandb:
+                wandb.log(
+                    {
+                        "train/loss": avg_loss,
+                        "train/lr": lr,
+                        "train/tokens_per_sec": tokens_per_sec,
+                        "train/grad_norm": grad_norm.item(),
+                    },
+                    step=iter_num + 1,
+                )
             running_loss = 0.0
             t0 = time.time()
 
@@ -495,6 +529,8 @@ def train(config: TrainConfig):
         if master and (iter_num + 1) % config.eval_interval == 0:
             val_loss = evaluate(model, val_loader, config.eval_iters, device, ctx)
             print(f"{'>>> VAL':>8} | {lr:>10.2e} | {'':>12} | {val_loss:>10.4f} |")
+            if config.use_wandb:
+                wandb.log({"val/loss": val_loss}, step=iter_num + 1)
 
             if val_loss < best_val:
                 best_val = val_loss
@@ -542,6 +578,8 @@ def train(config: TrainConfig):
         save_checkpoint(
             model, optimizer, config.max_iters, 0.0, config, model_config, final_path
         )
+        if config.use_wandb:
+            wandb.finish()
 
     cleanup_ddp(ddp)
 


### PR DESCRIPTION
## Summary
- Add opt-in `--use_wandb` flag (default off) to both `pretrain.py` and `train.py`, plus `--wandb_project` / `--wandb_run_name`.
- Log train loss/perplexity/lr/tokens-per-sec at `log_interval`, val loss/perplexity at `eval_interval`, and gradient histograms via `wandb.watch` — master-process only under DDP, with `wandb.finish()` on completion.
- Document usage in README and script docstrings; ignore local `wandb/` run dirs in git.

Closes #15

## Test plan
- [x] Smoke-tested both scripts end-to-end in `WANDB_MODE=offline` — metrics logged correctly.
- [x] Ran a real SFT training test with `--use_wandb` against `data/sft_dataset.json` resuming from the pretrain checkpoint — confirmed loss/lr/grad_norm/tokens_per_sec streaming to the W&B run.