### PR TITLE
Fix causal mask being skipped during multi-token KV-cache prefill

### DIFF
--- a/model/attention.py
+++ b/model/attention.py
@@ -45,13 +45,22 @@ class MultiHeadAttention(nn.Module):
         K = self.W_k(x).view(B, T_new, self.n_heads, self.d_k).transpose(1, 2)
         V = self.W_v(x).view(B, T_new, self.n_heads, self.d_k).transpose(1, 2)
 
+        T_past = 0
         if cache is not None:
+            T_past = cache.k.shape[2] if cache.k is not None else 0
             K, V = cache.update(K, V)  # (B, H, T_past + T_new, dk)
 
         scores = torch.matmul(Q, K.transpose(-2, -1)) / math.sqrt(self.d_k)
 
-        if cache is None:
-            scores = scores.masked_fill(self.causal_mask[:T_new, :T_new], float("-inf"))
+        # Cached past positions are unconditionally visible (they precede every new
+        # token); only the T_new new positions need masking against each other. This
+        # matters for prefill, where T_new > 1 new tokens are processed in one shot
+        # with a cache attached — a single decode step (T_new == 1) needs no mask.
+        if T_new > 1:
+            causal = self.causal_mask[:T_new, :T_new]
+            scores[..., :, T_past:] = scores[..., :, T_past:].masked_fill(
+                causal, float("-inf")
+            )
 
         attn = self.attn_dropout(F.softmax(scores, dim=-1))
         out = torch.matmul(attn, V).transpose(1, 2).contiguous().view(B, T_new, C)


### PR DESCRIPTION
Fixes #17.

## The bug

`MultiHeadAttention.forward` in `model/attention.py` decided whether to apply the causal mask based on `if cache is None`:

```python
if cache is None:
    scores = scores.masked_fill(self.causal_mask[:T_new, :T_new], float("-inf"))
```

That's correct for a single-token decode step — one new token attending to its cached past is trivially causal, no mask needed. But `generate()`'s **prefill** call passes the *entire prompt* through in one shot with a cache already attached (`caches` is non-`None`, and `T_new == prompt_len`, often > 1). So prefill hit the `cache is not None` branch and skipped masking entirely — every prompt token could attend to *future* prompt tokens, not just past ones.

That non-causal leakage gets baked into the K/V tensors written into the cache (the contaminated hidden state at each position propagates through the layers into what's cached). Every decode step afterward attends against that corrupted cache, so generated text diverges from what the model actually learned — often within one or two tokens.

Training was never affected: `model(x, targets=y)` never passes a cache, so it always hit the `cache is None` branch. This bug only affected `generate()`/`inference.py`.

## Why this was hard to notice

A model trained to very low loss (~0.06, deliberately overfit/memorized on `data/sft_dataset.json`) still produced fluent-but-wrong generations. Loss looked great; output looked broken. Isolating it:

```python
# Ground truth: full forward, no cache, prompt + first generated token
logits_full2, _ = model(full_seq, caches=None, start_pos=0)
pred_full2 = logits_full2[0, -1].argmax().item()   # "name" -- matches training data

# Same weights, same context, via the cache populated by prefill
logits_dec, _ = model(next_tok, caches=caches, start_pos=len(prompt_ids))
pred_dec = logits_dec[0, -1].argmax().item()        # "wife" -- wrong
```

Same model, same effective context, different answer — the only difference is that the second path's cache was populated by an unmasked (non-causal) prefill.

## The fix

Branch on whether there are multiple new query positions that could see each other's future, not on whether a cache is present:

```python
if T_new > 1:
    causal = self.causal_mask[:T_new, :T_new]
    scores[..., :, T_past:] = scores[..., :, T_past:].masked_fill(causal, float("-inf"))
```

`T_past` is the cache length *before* this call's new tokens were appended, captured before `cache.update()` overwrites `K`/`V`. Cached past positions are unconditionally causal-valid (they precede every new token by construction) and never need masking — only the new-token block needs masking against itself.

This is a no-op for the two cases that already worked:
- Training / any `cache is None` call: `T_past == 0`, so this masks the entire `T_new × T_new` block — identical to the old behavior.
- Single-token decode: `T_new == 1`, so the `if` is skipped — identical to the old behavior (no mask needed).

It only changes behavior for multi-token prefill with a cache attached, which was the broken case.

## Verification

After the fix, the isolation test above returns "name" for both paths (cached and non-cached agree), and `inference.py` reproduces memorized training answers exactly instead of diverging after the first token. Confirmed on several held-in prompts from `data/sft_dataset.json` at a range of answer lengths.

## Scope note

This branch contains only the attention fix. There are other in-progress local changes (`data_utils.py`/`train.py`, supporting a val-merged/no-validation training mode) that are unrelated to this bug and intentionally left off this PR.