### PR TITLE
Add local browser chat UI for interactively testing checkpoints

### DIFF
--- a/chat_demo.py
+++ b/chat_demo.py
@@ -1,0 +1,168 @@
+"""
+chat_demo.py — minimal multi-turn demo.
+
+Feeds a sequence of questions one at a time, using the model's own real generated
+answer (not any ground-truth text) as context for the next turn -- exactly the
+growing-transcript mechanics a real chat session would use. No new generation
+machinery: this is just prompt bookkeeping around model/generate.py's existing
+KV-cache generate().
+
+Two prompt formats, matching whichever pipeline the checkpoint was trained with:
+  --format qa      "<BOS> Question: ...\\nAnswer: ...\\nQuestion: ...\\nAnswer: ..."
+                    (data_utils.QA_TEMPLATE / prepare_custom_data). Stops on <EOS>,
+                    which this format only ever emits at the very end of a fixed-2-turn
+                    example, so a spillover second Question:/Answer: pair is truncated
+                    off after the fact.
+  --format chatml   "<|im_start|>user\\n...<|im_end|>\\n<|im_start|>assistant\\n..."
+                    (data_utils.encode_conversation / prepare_multiturn_data). Stops on
+                    <|im_end|>, which is emitted after *every* turn, so no post-hoc
+                    truncation hack is needed -- generation should just stop cleanly.
+
+USAGE:
+    python chat_demo.py --checkpoint checkpoints/smalltalk_demo_v2/final.pt \\
+        --turns "Hello" "Can you tell me a joke?"
+    python chat_demo.py --checkpoint checkpoints/multiturn_chatml_test/final.pt \\
+        --tokenizer_path data/tokenizer_multiturn_chatml.json --format chatml \\
+        --turns "Hello" "Can you tell me a joke?"
+"""
+
+import argparse
+
+import torch
+
+from model import ModelConfig, TinyLLM
+from model.generate import generate
+from tokenizer import BPETokenizer
+
+
+def load_model(checkpoint_path: str, device: torch.device) -> TinyLLM:
+    checkpoint = torch.load(checkpoint_path, map_location=device)
+    cfg_dict = {k: v for k, v in checkpoint["model_config"].items() if k != "d_k"}
+    model = TinyLLM(ModelConfig(**cfg_dict)).to(device)
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+    return model
+
+
+def _format_question(format: str, question: str) -> str:
+    if format == "qa":
+        return f"Question: {question}\nAnswer:"
+    return f"<|im_start|>user\n{question}<|im_end|>\n<|im_start|>assistant\n"
+
+
+def _format_answer(format: str, answer: str) -> str:
+    return f" {answer}\n" if format == "qa" else f"{answer}<|im_end|>\n"
+
+
+def render_prompt_prefix(format: str, history: list[tuple[str, str]]) -> str:
+    """Rebuild the running prompt text from completed (question, answer) turns.
+
+    Pure string formatting, no generation -- lets a stateless caller (e.g. webchat.py,
+    which gets the full history resent with every HTTP request instead of holding
+    conversation state itself) reconstruct exactly the prompt run_chat/generate_reply
+    would have built up turn-by-turn, without re-running generation for turns whose
+    answer is already known.
+    """
+    prompt = "<BOS> " if format == "qa" else ""
+    for question, answer in history:
+        prompt += _format_question(format, question) + _format_answer(format, answer)
+    return prompt
+
+
+def generate_reply(
+    model: TinyLLM,
+    tokenizer: BPETokenizer,
+    device: torch.device,
+    prompt_so_far: str,
+    question: str,
+    format: str = "qa",
+    max_new_tokens: int = 40,
+    temperature: float = 0.0,
+    top_k: int = 1,
+) -> tuple[str, str]:
+    """Generate one assistant reply given the running prompt text and a new question.
+
+    Returns (answer, updated_prompt) -- updated_prompt is prompt_so_far with this
+    turn's question and generated answer appended, ready to feed back in as
+    prompt_so_far for the next turn. Shared by run_chat's CLI loop and webchat.py's
+    HTTP handler so the two entry points can't drift out of sync on prompt formatting.
+    """
+    eos_id = tokenizer.eos_id if format == "qa" else tokenizer.im_end_id
+    prompt = prompt_so_far + _format_question(format, question)
+
+    ids = tokenizer.encode(prompt)
+    budget = model.config.context_length - len(ids) - 2
+    if budget <= 0:
+        return "(context full; stopping)", prompt
+
+    x = torch.tensor([ids], dtype=torch.long, device=device)
+    out = generate(
+        model, x, max_new_tokens=min(max_new_tokens, budget), temperature=temperature,
+        top_k=top_k, eos_id=eos_id,
+    )
+    answer = tokenizer.decode(out[0, len(ids):].tolist(), skip_special_tokens=True).strip()
+    if format == "qa":
+        # The QA-template model was trained exclusively on exactly-2-turn examples, so
+        # it tends to keep going and hallucinate a second Question:/Answer: pair of its
+        # own even when asked for just one turn -- same template-locking pattern as the
+        # fixed-hop-count issue found earlier, just for turn-count instead. Truncate at
+        # the first such spillover so each turn's answer is only this turn's answer.
+        # (This tokenizer's decode collapses newlines to spaces, so the split looks for
+        # " Question:", not the literal "\nQuestion:" that appears in the training text
+        # before encoding.)
+        answer = answer.split(" Question:")[0].strip()
+    # chatml stops on <|im_end|> after every turn (see encode_conversation), so no
+    # equivalent post-hoc truncation should be needed there.
+
+    prompt += _format_answer(format, answer)
+    return answer, prompt
+
+
+def run_chat(
+    checkpoint_path: str,
+    tokenizer_path: str,
+    turns: list[str],
+    max_new_tokens: int = 40,
+    temperature: float = 0.0,
+    top_k: int = 1,
+    format: str = "qa",
+) -> list[tuple[str, str]]:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = load_model(checkpoint_path, device)
+    tokenizer = BPETokenizer.load(tokenizer_path)
+
+    prompt = "<BOS> " if format == "qa" else ""
+    results = []
+    for question in turns:
+        answer, prompt = generate_reply(
+            model, tokenizer, device, prompt, question, format,
+            max_new_tokens, temperature, top_k,
+        )
+        if answer == "(context full; stopping)":
+            print(answer)
+            break
+        print(f"You:     {question}")
+        print(f"TinyLLM: {answer}")
+        results.append((question, answer))
+
+    return results
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Minimal multi-turn chat demo")
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--tokenizer_path", default="checkpoints/tokenizer.json")
+    p.add_argument("--turns", nargs="+", required=True, help="one or more questions, asked in sequence")
+    p.add_argument("--max_new_tokens", type=int, default=40)
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--top_k", type=int, default=1)
+    p.add_argument("--format", choices=["qa", "chatml"], default="qa")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run_chat(
+        args.checkpoint, args.tokenizer_path, args.turns,
+        args.max_new_tokens, args.temperature, args.top_k, args.format,
+    )

--- a/tokenizer/tokenizer.py
+++ b/tokenizer/tokenizer.py
@@ -58,6 +58,17 @@ class BPETokenizer:
     def eos_id(self) -> int:
         return self.encoder["<EOS>"]
 
+    @property
+    def im_start_id(self) -> int:
+        return self.encoder["<|im_start|>"]
+
+    @property
+    def im_end_id(self) -> int:
+        """ChatML message delimiter -- also the token generation should stop on after an
+        assistant message (pass as generate()'s eos_id when sampling from a
+        multi-turn-trained checkpoint; plain <EOS> never appears in that format)."""
+        return self.encoder["<|im_end|>"]
+
     # ------------------------------------------------------------------
     # Extending an already-trained tokenizer
     # ------------------------------------------------------------------

--- a/webchat.py
+++ b/webchat.py
@@ -1,0 +1,138 @@
+"""
+webchat.py — local browser chat UI for interactively testing a TinyLLM checkpoint.
+
+The CLI demo (chat_demo.py) only proves the pipeline runs -- it doesn't let you poke at
+it yourself, which is the actual point of testing "does turn 2's answer track what I
+just typed, or is it a memorized script for this opener." This serves the same
+generation logic (chat_demo.generate_reply, so there is exactly one place that builds
+qa/chatml prompts) over a tiny stdlib-only HTTP server plus a static chat page, so you
+can type arbitrary follow-ups in a browser and watch the *live* answer come back.
+
+Stateless by design: the browser resends the full conversation history with every
+request and the server rebuilds the prompt from scratch each time (chat_demo.
+render_prompt_prefix) -- no session/conversation state lives on the server between
+requests, the same mechanic real chat APIs use (see data_utils.encode_conversation's
+docstring on why the model is only ever scored on assistant spans).
+
+No extra dependencies -- uses only Python's stdlib http.server, so nothing to pip
+install beyond what training already needs.
+
+USAGE:
+    python webchat.py --checkpoint checkpoints/multiturn_chatml_test/final.pt \\
+        --tokenizer_path data/tokenizer_multiturn_chatml.json --format chatml
+    Then open http://127.0.0.1:8765 in a browser.
+"""
+
+import argparse
+import json
+import os
+import webbrowser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import torch
+
+from chat_demo import generate_reply, load_model, render_prompt_prefix
+from tokenizer import BPETokenizer
+
+STATIC_HTML_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "webchat_ui.html")
+
+
+def make_handler(model, tokenizer, device, format: str, checkpoint_path: str, tokenizer_path: str):
+    n_params = sum(p.numel() for p in model.parameters())
+
+    class Handler(BaseHTTPRequestHandler):
+        def _send_json(self, status: int, payload: dict):
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path == "/":
+                with open(STATIC_HTML_PATH, "rb") as f:
+                    body = f.read()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            elif self.path == "/info":
+                self._send_json(200, {
+                    "checkpoint": checkpoint_path,
+                    "tokenizer_path": tokenizer_path,
+                    "format": format,
+                    "params": f"{n_params / 1e6:.2f}M params",
+                })
+            else:
+                self._send_json(404, {"error": "not found"})
+
+        def do_POST(self):
+            if self.path != "/chat":
+                self._send_json(404, {"error": "not found"})
+                return
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(length) or b"{}")
+                message = str(body.get("message", "")).strip()
+                history = [
+                    (str(turn["question"]), str(turn["answer"]))
+                    for turn in body.get("history", [])
+                ]
+                if not message:
+                    self._send_json(400, {"error": "empty message"})
+                    return
+
+                temperature = float(body.get("temperature", 0.0))
+                top_k = int(body.get("top_k", 1))
+                max_new_tokens = int(body.get("max_new_tokens", 40))
+
+                prompt_prefix = render_prompt_prefix(format, history)
+                answer, _ = generate_reply(
+                    model, tokenizer, device, prompt_prefix, message, format,
+                    max_new_tokens, temperature, top_k,
+                )
+                self._send_json(200, {"answer": answer})
+            except Exception as e:  # noqa: BLE001 -- surface any failure to the browser instead of a dropped connection
+                self._send_json(500, {"error": str(e)})
+
+        def log_message(self, fmt, *args):
+            print(f"[webchat] {self.address_string()} - {fmt % args}")
+
+    return Handler
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Local browser chat UI for a TinyLLM checkpoint")
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--tokenizer_path", default="checkpoints/tokenizer.json")
+    parser.add_argument("--format", choices=["qa", "chatml"], default="qa")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--no_browser", action="store_true", help="don't auto-open a browser tab")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Loading checkpoint {args.checkpoint} on {device}...")
+    model = load_model(args.checkpoint, device)
+    tokenizer = BPETokenizer.load(args.tokenizer_path)
+
+    handler = make_handler(model, tokenizer, device, args.format, args.checkpoint, args.tokenizer_path)
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    url = f"http://{args.host}:{args.port}"
+    print(f"Serving TinyLLM chat UI at {url} (format={args.format})")
+    if not args.no_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping.")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/webchat_ui.html
+++ b/webchat_ui.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>TinyLLM chat</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg: #f5f5f7; --panel: #ffffff; --text: #1c1c1e; --muted: #6e6e73;
+    --bubble-user: #0a84ff; --bubble-user-text: #ffffff;
+    --bubble-bot: #e9e9eb; --bubble-bot-text: #1c1c1e;
+    --border: #d8d8dc; --accent: #0a84ff;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #1c1c1e; --panel: #2c2c2e; --text: #f2f2f7; --muted: #9a9a9e;
+      --bubble-bot: #3a3a3c; --bubble-bot-text: #f2f2f7; --border: #48484a; }
+  }
+  :root[data-theme="dark"] { --bg: #1c1c1e; --panel: #2c2c2e; --text: #f2f2f7; --muted: #9a9a9e;
+    --bubble-bot: #3a3a3c; --bubble-bot-text: #f2f2f7; --border: #48484a; }
+  :root[data-theme="light"] { --bg: #f5f5f7; --panel: #ffffff; --text: #1c1c1e; --muted: #6e6e73;
+    --bubble-bot: #e9e9eb; --bubble-bot-text: #1c1c1e; --border: #d8d8dc; }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg); color: var(--text); height: 100vh; display: flex; flex-direction: column;
+  }
+  header {
+    padding: 12px 16px; border-bottom: 1px solid var(--border); background: var(--panel);
+    display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+  }
+  header h1 { font-size: 15px; margin: 0; font-weight: 600; }
+  #meta { font-size: 12px; color: var(--muted); overflow-wrap: anywhere; }
+  #warnBanner {
+    display: none; background: #fff4ce; color: #7a5b00; font-size: 12px; padding: 6px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  :root[data-theme="dark"] #warnBanner, @media (prefers-color-scheme: dark) { }
+  main {
+    flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 10px;
+  }
+  .row { display: flex; }
+  .row.user { justify-content: flex-end; }
+  .row.bot { justify-content: flex-start; }
+  .bubble {
+    max-width: min(70ch, 80%); padding: 9px 13px; border-radius: 16px; line-height: 1.4;
+    font-size: 14px; white-space: pre-wrap; word-wrap: break-word;
+  }
+  .row.user .bubble { background: var(--bubble-user); color: var(--bubble-user-text); border-bottom-right-radius: 4px; }
+  .row.bot .bubble { background: var(--bubble-bot); color: var(--bubble-bot-text); border-bottom-left-radius: 4px; }
+  .row.bot .bubble.pending { color: var(--muted); font-style: italic; }
+  .row.bot .bubble.err { background: #ff453a; color: white; }
+  footer {
+    border-top: 1px solid var(--border); background: var(--panel); padding: 10px 12px;
+    display: flex; gap: 8px; align-items: flex-end;
+  }
+  #msg {
+    flex: 1; resize: none; border: 1px solid var(--border); border-radius: 10px; padding: 9px 12px;
+    font-size: 14px; font-family: inherit; background: var(--bg); color: var(--text); max-height: 120px;
+  }
+  #msg:focus { outline: 2px solid var(--accent); }
+  button {
+    border: none; border-radius: 10px; padding: 9px 16px; font-size: 14px; font-weight: 600;
+    cursor: pointer; background: var(--accent); color: white;
+  }
+  button:disabled { opacity: .5; cursor: default; }
+  button.secondary { background: transparent; color: var(--muted); border: 1px solid var(--border); }
+  #controls { display: flex; gap: 14px; padding: 8px 16px; font-size: 12px; color: var(--muted);
+    border-bottom: 1px solid var(--border); background: var(--panel); flex-wrap: wrap; align-items: center; }
+  #controls label { display: flex; gap: 4px; align-items: center; }
+  #controls input[type="number"] { width: 56px; background: var(--bg); color: var(--text);
+    border: 1px solid var(--border); border-radius: 6px; padding: 2px 4px; }
+  #empty { color: var(--muted); font-size: 13px; text-align: center; margin-top: 40px; }
+</style>
+</head>
+<body>
+  <header>
+    <h1>TinyLLM chat</h1>
+    <span id="meta">loading model info…</span>
+  </header>
+  <div id="controls">
+    <label>temperature <input id="temperature" type="number" step="0.1" min="0" max="2" value="0"></label>
+    <label>top_k <input id="topk" type="number" step="1" min="1" max="200" value="1"></label>
+    <label>max new tokens <input id="maxtok" type="number" step="5" min="5" max="200" value="40"></label>
+    <button class="secondary" id="resetBtn" type="button">New conversation</button>
+  </div>
+  <main id="log">
+    <div id="empty">No messages yet — say hello below. Each reply is generated fresh from the model given the full conversation so far (nothing here is canned).</div>
+  </main>
+  <footer>
+    <textarea id="msg" rows="1" placeholder="Type a message…"></textarea>
+    <button id="sendBtn" type="button">Send</button>
+  </footer>
+
+<script>
+const log = document.getElementById('log');
+const msgBox = document.getElementById('msg');
+const sendBtn = document.getElementById('sendBtn');
+const resetBtn = document.getElementById('resetBtn');
+const metaEl = document.getElementById('meta');
+const empty = document.getElementById('empty');
+
+let history = []; // [{question, answer}, ...]
+
+fetch('/info').then(r => r.json()).then(info => {
+  metaEl.textContent =
+    `checkpoint: ${info.checkpoint} · tokenizer: ${info.tokenizer_path} · format: ${info.format} · ${info.params}`;
+}).catch(() => { metaEl.textContent = '(could not load model info)'; });
+
+function addBubble(role, text, opts) {
+  opts = opts || {};
+  if (empty.parentNode) empty.remove();
+  const row = document.createElement('div');
+  row.className = 'row ' + (role === 'user' ? 'user' : 'bot');
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble' + (opts.pending ? ' pending' : '') + (opts.err ? ' err' : '');
+  bubble.textContent = text;
+  row.appendChild(bubble);
+  log.appendChild(row);
+  log.scrollTop = log.scrollHeight;
+  return bubble;
+}
+
+async function send() {
+  const text = msgBox.value.trim();
+  if (!text) return;
+  msgBox.value = '';
+  msgBox.style.height = 'auto';
+  sendBtn.disabled = true;
+  addBubble('user', text);
+  const pending = addBubble('bot', 'thinking…', { pending: true });
+
+  try {
+    const resp = await fetch('/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        history: history,
+        message: text,
+        temperature: parseFloat(document.getElementById('temperature').value) || 0,
+        top_k: parseInt(document.getElementById('topk').value, 10) || 1,
+        max_new_tokens: parseInt(document.getElementById('maxtok').value, 10) || 40,
+      }),
+    });
+    if (!resp.ok) {
+      const errText = await resp.text();
+      pending.textContent = 'Error: ' + errText;
+      pending.classList.remove('pending');
+      pending.classList.add('err');
+      return;
+    }
+    const data = await resp.json();
+    pending.textContent = data.answer;
+    pending.classList.remove('pending');
+    history.push({ question: text, answer: data.answer });
+  } catch (e) {
+    pending.textContent = 'Request failed: ' + e;
+    pending.classList.remove('pending');
+    pending.classList.add('err');
+  } finally {
+    sendBtn.disabled = false;
+    msgBox.focus();
+  }
+}
+
+sendBtn.addEventListener('click', send);
+msgBox.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+});
+msgBox.addEventListener('input', () => {
+  msgBox.style.height = 'auto';
+  msgBox.style.height = Math.min(msgBox.scrollHeight, 120) + 'px';
+});
+resetBtn.addEventListener('click', () => {
+  history = [];
+  log.innerHTML = '';
+  log.appendChild(empty);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `webchat.py`: stdlib-only local HTTP server (no new dependencies) that loads a checkpoint + tokenizer once and serves a chat page plus a stateless `/chat` endpoint (the browser resends the full conversation history each request; the server rebuilds the prompt from scratch).
- `webchat_ui.html`: single-page chat UI (message bubbles, temperature/top_k/max-tokens controls, reset button).
- `chat_demo.py`: generation logic factored into `generate_reply()`/`render_prompt_prefix()` so the CLI demo and the new browser UI share exactly one prompt-formatting code path (`qa` and `chatml` formats) instead of two that could drift.
- `tokenizer/tokenizer.py`: adds `im_start_id`/`im_end_id` properties so generation can stop on `<|im_end|>` for chatml-formatted checkpoints.

Closes #20.

## Scope note
This PR is intentionally just the UI + its direct dependency (the tokenizer property `chat_demo.py` needs for `--format chatml` to not raise `AttributeError`). It does **not** include the multi-turn data/training pipeline changes (`data_utils.py`, `tokenizer/constants.py`'s special-token list, `train.py`'s `--dataset_type`, `generate_smalltalk_multiturn.py`, `build_smalltalk_demo_dataset.py`) — those are a separate, larger piece of in-progress work and will land as their own PR. Until that lands, `--format qa` is the fully-supported path; `--format chatml` needs a tokenizer already containing `<|im_start|>`/`<|im_end|>` (e.g. one trained locally against the in-progress pipeline).

## Test plan
- [x] Started `webchat.py` against a locally-trained chatml checkpoint, confirmed `/info` and `/chat` respond correctly via curl.
- [x] Verified the same opener ("Hello") followed by two different follow-up questions produces two distinct, correctly-conditioned answers (not a memorized script).
- [x] Confirmed the page loads and empty-message requests return 400.
- [x] Manually click through the page in a browser (reviewer/user to confirm UX).